### PR TITLE
Save and restore selected jar artifact per function

### DIFF
--- a/sources/src/io/github/satr/idea/plugin/connector/la/models/ConnectorSettings.java
+++ b/sources/src/io/github/satr/idea/plugin/connector/la/models/ConnectorSettings.java
@@ -6,10 +6,13 @@ import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.util.xmlb.XmlSerializerUtil;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.http.util.TextUtils.isEmpty;
 
@@ -23,12 +26,34 @@ public class ConnectorSettings  implements PersistentStateComponent<ConnectorSet
     private String lastSelectedCredentialProfile;
     private String lastSelectedTestFunctionInputFilePath;
 
+    private Map<String, String> lastSelectedJarArtifactPerFunction = new HashMap<>();
+
     public String getLastSelectedJarArtifactName() {
         return lastSelectedJarArtifactName;
     }
 
     public void setLastSelectedJarArtifactName(String lastSelectedJarArtifactName) {
         this.lastSelectedJarArtifactName = lastSelectedJarArtifactName;
+
+        if (!isEmpty(lastSelectedFunctionName)) {
+            if (!isEmpty(lastSelectedJarArtifactName)) {
+                lastSelectedJarArtifactPerFunction.put(lastSelectedFunctionName, lastSelectedJarArtifactName);
+            } else {
+                lastSelectedJarArtifactPerFunction.remove(lastSelectedFunctionName);
+            }
+        }
+    }
+
+    public @Nullable String getLastSelectedJarArtifactNameForFunction(@NotNull String functionName) {
+        return lastSelectedJarArtifactPerFunction.getOrDefault(functionName, null);
+    }
+
+    public Map<String, String> getLastSelectedJarArtifactPerFunction() {
+        return lastSelectedJarArtifactPerFunction;
+    }
+
+    public void setLastSelectedJarArtifactPerFunction(Map<String, String> lastSelectedJarArtifactPerFunction) {
+        this.lastSelectedJarArtifactPerFunction = lastSelectedJarArtifactPerFunction;
     }
 
     public String getLastSelectedFunctionName() {
@@ -69,7 +94,8 @@ public class ConnectorSettings  implements PersistentStateComponent<ConnectorSet
 
     private void clearLastSelectedFunctionOnChangedRegion(String lastSelectedRegionName) {
         if((isEmpty(lastSelectedRegionName) && !isEmpty(this.lastSelectedRegionName))
-                || (!isEmpty(lastSelectedRegionName) && !lastSelectedRegionName.equals(this.lastSelectedRegionName))){
+                || (!isEmpty(lastSelectedRegionName) && !lastSelectedRegionName.equals(this.lastSelectedRegionName)
+                        && !isEmpty(this.lastSelectedRegionName))){
             setLastSelectedFunctionName("");
         }
     }

--- a/sources/src/io/github/satr/idea/plugin/connector/la/ui/ConnectorPresenterImpl.java
+++ b/sources/src/io/github/satr/idea/plugin/connector/la/ui/ConnectorPresenterImpl.java
@@ -8,6 +8,7 @@ import io.github.satr.common.*;
 import io.github.satr.idea.plugin.connector.la.entities.*;
 import io.github.satr.idea.plugin.connector.la.models.FunctionConnectorModel;
 import io.github.satr.idea.plugin.connector.la.models.RoleConnectorModel;
+import org.apache.http.util.TextUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -323,6 +324,14 @@ public class ConnectorPresenterImpl extends AbstractConnectorPresenter implement
         }
         getLogger().logDebug("Refresh JAR-artifact list.");
         String lastSelectedJarArtifactName = getConnectorSettings().getLastSelectedJarArtifactName();
+        if (view.getSelectedFunctionEntity() != null) {
+            String lastSelectedArtifactForSelectedFunction =
+                    getConnectorSettings().getLastSelectedJarArtifactNameForFunction(
+                            view.getSelectedFunctionEntity().getFunctionName());
+            if (!TextUtils.isEmpty(lastSelectedArtifactForSelectedFunction)) {
+                lastSelectedJarArtifactName = lastSelectedArtifactForSelectedFunction;
+            }
+        }
         ArtifactEntity selectedArtifactEntity = null;
         Collection<? extends ArtifactEntity> jarArtifacts = projectModel.getJarArtifacts();
         for(ArtifactEntity entity : jarArtifacts){
@@ -431,19 +440,23 @@ public class ConnectorPresenterImpl extends AbstractConnectorPresenter implement
             getLogger().logDebug("Function not set.");
         }
         refreshRolesList();
+        if (functionEntity != null) {
+            view.updateFunctionEntity(functionEntity);
+        }
         view.setFunctionConfiguration(functionEntity);
         if(autoRefreshAwsLog) {
             refreshAwsLogStreamList(functionEntity);
         } else {
             view.clearAwsLogStreamList();
         }
+        refreshJarArtifactList();
         refreshStatus();
     }
 
     @Override
     public void setJarArtifact(ArtifactEntity artifactEntity) {
         getLogger().logDebug("Set JAR-artifact.");
-        getConnectorSettings().setLastSelectedFunctionName(artifactEntity.getName());
+        getConnectorSettings().setLastSelectedJarArtifactName(artifactEntity.getName());
         refreshStatus();
     }
 


### PR DESCRIPTION
Added saving and restoring of selected jar artifact per function for better support of projects with multiple jar outputs. Demo - https://www.youtube.com/watch?v=VSTGCgT8sFE

Also fixed last selected function restoration after project relaunch (previously it was always selecting first one in the list).